### PR TITLE
Enhance editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+eclint_block_comment_start = /*
+eclint_block_comment = *
+eclint_block_comment_end = */


### PR DESCRIPTION
These [non-standard keys](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#ideas-for-domain-specific-properties) allow eclint to recognize `/* */`-style comments.

From https://github.com/conedevelopment/sprucecss/pull/12#issuecomment-1683749305

Let's see CI run!